### PR TITLE
Raytrace rearrangements

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -21,6 +21,7 @@ parseInput(inputPars *par, image **img, molData **m){
   FILE *fp;
   int i,id;
   double BB[3];
+  double cosPhi,sinPhi,cosTheta,sinTheta;
 
   /* Set default values */
   par->dust  	    = NULL;
@@ -152,6 +153,36 @@ parseInput(inputPars *par, image **img, molData **m){
       (*img)[i].pixel[id].intense = malloc(sizeof(double)*(*img)[i].nchan);
       (*img)[i].pixel[id].tau = malloc(sizeof(double)*(*img)[i].nchan);
     }
+
+    /* Rotation matrix
+
+            |1          0           0   |
+     R_x(a)=|0        cos(a)      sin(a)|
+            |0       -sin(a)      cos(a)|
+
+            |cos(b)     0       -sin(b)|
+     R_y(b)=|  0        1          0   |
+            |sin(b)     0        cos(b)|
+
+            |      cos(b)       0          -sin(b)|
+     Rot =  |sin(a)sin(b)     cos(a)  sin(a)cos(b)|
+            |cos(a)sin(b)    -sin(a)  cos(a)cos(b)|
+
+    */
+
+    cosPhi   = cos((*img)[i].phi);
+    sinPhi   = sin((*img)[i].phi);
+    cosTheta = cos((*img)[i].theta);
+    sinTheta = sin((*img)[i].theta);
+    (*img)[i].rotMat[0][0] =           cosPhi;
+    (*img)[i].rotMat[0][1] =  0.0;
+    (*img)[i].rotMat[0][2] =          -sinPhi;
+    (*img)[i].rotMat[1][0] =  sinTheta*sinPhi;
+    (*img)[i].rotMat[1][1] =  cosTheta;
+    (*img)[i].rotMat[1][2] =  sinTheta*cosPhi;
+    (*img)[i].rotMat[2][0] =  cosTheta*sinPhi;
+    (*img)[i].rotMat[2][1] = -sinTheta;
+    (*img)[i].rotMat[2][2] =  cosTheta*cosPhi;
   }
 
   /* Allocate moldata array */

--- a/src/curses.c
+++ b/src/curses.c
@@ -17,9 +17,13 @@
 
 void
 greetings(){
-	initscr();
-	printw("*** LIME, The versatile line modeling engine, Ver.1.31\n*** Copyright 2006--2014, Christian Brinch <brinch@nbi.dk>\n");
-	refresh();	
+  initscr();
+#ifdef TEST
+  printw("*** LIME, The versatile line modeling engine, Ver.1.31\n*** Copyright 2006--2014, Christian Brinch <brinch@nbi.dk>\n>>> NOTE! Test flag is set in the Makefile. <<<\n");
+#else
+  printw("*** LIME, The versatile line modeling engine, Ver.1.31\n*** Copyright 2006--2014, Christian Brinch <brinch@nbi.dk>\n");
+#endif
+  refresh();	
 }
 
 void

--- a/src/lime.h
+++ b/src/lime.h
@@ -147,6 +147,7 @@ typedef struct {
   double source_vel;
   double theta,phi;
   double distance;
+  double rotMat[3][3];
 } image;
 
 typedef struct {

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -182,7 +182,6 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
               }
               subintens[ichan]+=exp(-tau[ichan])*(1.-exp(-dtau))*snu;
               tau[ichan]+=dtau;
-
             }
           }
 

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -66,13 +66,16 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
   double *tau, *subintens;
   double vfac=0.,x[3],dx[3];
   double deltav,ds,dist2,ndist2,size,xp,yp,zp,col,shift,minfreq,absDeltaFreq,jnu,alpha,snu,dtau,snu_pol[3];
+
   gsl_rng *ran = gsl_rng_alloc(gsl_rng_ranlxs2);	/* Random number generator */
 #ifdef TEST
   gsl_rng_set(ran,178490);
 #else
   gsl_rng_set(ran,time(0));
 #endif
-  
+
+  size=img[im].distance*img[im].imgres;
+
   /* Determine whether there are blended lines or not */
   lineCount(par->nSpecies, m, &counta, &countb, &nlinetot);
   if(img[im].doline==0) nlinetot=1;
@@ -113,8 +116,6 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
         tau[ichan]=0.0;
         subintens[ichan]=0.0;
       }
-      size=img[im].distance*img[im].imgres;
-
       xp=size*(gsl_rng_uniform(ran)+px%img[im].pxls)-size*img[im].pxls/2.;
       yp=size*(gsl_rng_uniform(ran)+px/img[im].pxls)-size*img[im].pxls/2.;
 

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -118,7 +118,8 @@ traceray(rayData ray, int tmptrans, int im, inputPars *par, struct grid *g, molD
           dtau=0.;
 
           for(iline=0;iline<nlinetot;iline++){
-            if(img[im].doline && m[counta[iline]].freq[countb[iline]] > img[im].freq-img[im].bandwidth/2. && m[counta[iline]].freq[countb[iline]] < img[im].freq+img[im].bandwidth/2.){
+            if(img[im].doline && m[counta[iline]].freq[countb[iline]] > img[im].freq-img[im].bandwidth/2.
+            && m[counta[iline]].freq[countb[iline]] < img[im].freq+img[im].bandwidth/2.){
               if(img[im].trans > -1){
                 shift=(m[counta[iline]].freq[countb[iline]]-m[counta[iline]].freq[img[im].trans])/m[counta[iline]].freq[img[im].trans]*CLIGHT;
               } else {

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -66,15 +66,10 @@ line_plane_intersect(struct grid *g, double *ds, int posn, int *nposn, double *d
 void
 traceray(rayData ray, int tmptrans, int im, inputPars *par, struct grid *g, molData *m, image *img, int nlinetot, int *counta, int *countb){
   int ichan,posn,nposn,i,iline;
-//  double *tau, *subintens;
   double vfac=0.,x[3],dx[3];
   double deltav,ds,dist2,ndist2,xp,yp,zp,col,shift,jnu,alpha,snu,dtau,snu_pol[3];
 
-//  tau = malloc(sizeof(double)*img[im].nchan);
-//  subintens = malloc(sizeof(double)*img[im].nchan);
   for(ichan=0;ichan<img[im].nchan;ichan++){
-//    tau[ichan]=0.0;
-//    subintens[ichan]=0.0;
     ray.tau[ichan]=0.0;
     ray.intensity[ichan]=0.0;
   }
@@ -112,8 +107,6 @@ traceray(rayData ray, int tmptrans, int im, inputPars *par, struct grid *g, molD
       if(par->polarization){
         for(ichan=0;ichan<img[im].nchan;ichan++){
           sourceFunc_pol(snu_pol,&dtau,ds,m,vfac,g,posn,0,0,img[im].theta);
-//          subintens[ichan]+=exp(-tau[ichan])*(1.-exp(-dtau))*snu_pol[ichan];
-//          tau[ichan]+=dtau;
           ray.intensity[ichan]+=exp(-ray.tau[ichan])*(1.-exp(-dtau))*snu_pol[ichan];
           ray.tau[ichan]+=dtau;
         }
@@ -147,8 +140,6 @@ traceray(rayData ray, int tmptrans, int im, inputPars *par, struct grid *g, molD
             snu=(jnu/alpha)*m[0].norminv;
             dtau=alpha*ds;
           }
-//          subintens[ichan]+=exp(-tau[ichan])*(1.-exp(-dtau))*snu;
-//          tau[ichan]+=dtau;
           ray.intensity[ichan]+=exp(-ray.tau[ichan])*(1.-exp(-dtau))*snu;
           ray.tau[ichan]+=dtau;
         }
@@ -162,17 +153,9 @@ traceray(rayData ray, int tmptrans, int im, inputPars *par, struct grid *g, molD
 
     /* add or subtract cmb */
     for(ichan=0;ichan<img[im].nchan;ichan++){
-//      subintens[ichan]+=(exp(-tau[ichan])-1.)*m[0].local_cmb[tmptrans];
       ray.intensity[ichan]+=(exp(-ray.tau[ichan])-1.)*m[0].local_cmb[tmptrans];
     }
   }
-//  for(ichan=0;ichan<img[im].nchan;ichan++){
-//    ray.intensity[ichan]=subintens[ichan];
-//    ray.tau[ichan]=tau[ichan];
-//  }
-
-//  free(tau);
-//  free(subintens);
 }
 
 
@@ -227,10 +210,6 @@ raytrace(int im, inputPars *par, struct grid *g, molData *m, image *img){
       img[im].pixel[px].tau[ichan]=0.0;
     }
     for(aa=0;aa<par->antialias;aa++){
-//      for(ichan=0;ichan<img[im].nchan;ichan++) {
-//        ray.intensity[ichan]=0.0;
-//        ray.tau[ichan]=0.0;
-//      }
       ray.x = size*(gsl_rng_uniform(ran)+px%img[im].pxls)-size*img[im].pxls/2.;
       ray.y = size*(gsl_rng_uniform(ran)+px/img[im].pxls)-size*img[im].pxls/2.;
 


### PR DESCRIPTION
The rearrangements (and added code) in this pull request ought not to change the output values of LIME. Their purpose is firstly to preserve code for an alternative raytracing algorithm which was first developed and present in version 1.4, and secondly to clear the ground for eventual addition of parallelization.